### PR TITLE
Note for Rockrobo S5 Max removed, already included in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,6 @@ If there is no entry, the command is available for each device.
 | SEGMENT_MERGE            | `merge_segment`             | -                                                 | s5e                |
 | SEGMENT_SPLIT            | `split_segment`             | -                                                 | s5e                |
 
-Rockrobo S5 Max (s5e)  and similar with water
-| Type        | Command           | Description                                      |
-| ------      | ---------         | -----------                                      |
-| SET_WATER   | `set_water_box_custom_mode` | Setting water level (parameter [200-204] |
-
 ## Generic MiIO Commands
 
 :information_source: These commands appear to be shared amongs all(?) Xiaomi Mi Io devices.


### PR DESCRIPTION
I forgot to remove the note for Rockrobo S5 Max. It is already in the list of commands with the note that the command is only available before s5e.