### PR TITLE
Added roborock s5e features

### DIFF
--- a/fw_features.md
+++ b/fw_features.md
@@ -49,5 +49,9 @@ Retrieves a list of supported firmware features of the device.
 | 116  | ?           |
 | 117  | ?           |
 | 118  | ?           |
+| 119  | ?           |
+| 120  | ?           |
 | 122  | ?           |
+| 123  | ?           |
+| 124  | ?           |
 | 125  | ?           |


### PR DESCRIPTION
My s5e returns a list with more feature ids:

```bash
→ miio protocol call 192.168.178.24 get_fw_features
 INFO  Attempting to call get_fw_features on 192.168.178.24

 INFO  Device found, making call

 INFO  Got result:
[
  111,
  112,
  113,
  114,
  115,
  116,
  117,
  118,
  119,
  120,
  122,
  123,
  124,
  125
]
```